### PR TITLE
Add build requirements for python-ldap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,3 +31,10 @@ RUN apt-get update && apt-get install -y \
     # Cleanup
     && rm *.deb \
     && rm -rf /var/lib/apt/lists/*
+
+# Install build requirements for python-ldap
+RUN apt-get update && apt-get install -y \
+    libldap2-dev \
+    ldap-utils \
+    libsasl2-dev \
+    && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 FROM tiangolo/uvicorn-gunicorn-fastapi:python3.10
 
 # Install pandoc for generating the PDF report
-RUN apt-get update && apt-get install -y pandoc
+RUN apt-get update && apt-get install -y pandoc && rm -rf /var/lib/apt/lists/*
 
 # Install wkhtmltopdf 0.12.5 (with patched qt) and it's dependencies
 # See https://gist.github.com/Rajeshr34/2e9b2438ff142e51c729b4b9b772680a
-RUN apt-get install -y \
+RUN apt-get update && apt-get install -y \
     build-essential \
     fontconfig \
     git-core \
@@ -21,7 +21,13 @@ RUN apt-get install -y \
     xfonts-base \
     xfonts-encodings \
     xfonts-utils \
-	&& wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.buster_amd64.deb \
+    # Install libssl1.1_1 (required for wkhtmltopdf)
+    && wget -q http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_amd64.deb \
+    && dpkg -i libssl1.1_1.1.1f-1ubuntu2_amd64.deb \
+    # Install wkhtmltopdf
+	&& wget -q https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.buster_amd64.deb \
 	&& dpkg -i wkhtmltox_0.12.5-1.buster_amd64.deb \
-	&& apt --fix-broken install
-RUN rm -rf /var/lib/apt/lists/*
+	&& apt --fix-broken install \
+    # Cleanup
+    && rm *.deb \
+    && rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ Published on the Docker Hub: https://hub.docker.com/r/symptoma/uvicorn-gunicorn-
 Current version of the base image is **0.7.0**: https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker/releases/tag/0.7.0
 
 ## Build
-
+```
 docker build -t symptoma/uvicorn-gunicorn-fastapi-pandoc .
+```
 
 ## Publish
 


### PR DESCRIPTION
### Description

As we need to install `python-ldap` downstream, this base image should include the [build prerequisites](https://www.python-ldap.org/en/python-ldap-3.4.3/installing.html#build-prerequisites) for it. 

This PR adds the installation of those to the `Dockerfile`.

Additionally, the install of `wkhtmltopdf` is fixed by installing `libssl1` - I assume that this was in the base image `tiangolo/uvicorn-gunicorn-fastapi:python3.10` before but is not anymore. Now it is installed additionally from the Ubuntu archive.

### How to test:
- [x] Build the image and ensure it works: `docker build -t symptoma/uvicorn-gunicorn-fastapi-pandoc .`